### PR TITLE
🚑 핫부스 실시간성 재반영

### DIFF
--- a/booth/views.py
+++ b/booth/views.py
@@ -1,5 +1,6 @@
 import secrets
 
+from django.utils import timezone
 from django.shortcuts import render
 from django.db.models import Count, F, ExpressionWrapper, DateField
 from django.db.models.functions import Extract
@@ -42,6 +43,9 @@ class BoothViewSet(viewsets.GenericViewSet, mixins.ListModelMixin, mixins.Retrie
     # 핫부스 TOP3
     @action(methods=['GET'], detail=False)
     def hot(self, request):
+        # 실제로 서비스하면 아래 코드로 바꾸겟습니다.
+        # current_time = timezone.now()
+        # top3 = self.get_queryset().filter(start_at__lte=current_time, end_at__gte=current_time).order_by('-like_cnt')[:3]
         top3 = self.get_queryset().order_by('-like_cnt')[:3]
         top3_serializer = BoothListSerializer(top3, many=True, context = {'request': request})
         return Response( top3_serializer.data )


### PR DESCRIPTION
부스 다중 이미지 추가 때 마찬가지로 지워진 것 같습니다.
프론트 api 테스트를 고려해서 실시간성은 주석으로 반영했습니다.
추후에 서비스 전에 바꾸거나 1차적으로 테스트 완료되면 바꾸도록 하겠습니다.

